### PR TITLE
add configuração prefeitura do rio de janeiro

### DIFF
--- a/src/Common/Tools.php
+++ b/src/Common/Tools.php
@@ -51,6 +51,15 @@ class Tools
             'version' => '1.00',
             'msgns' => 'http://www.abrasf.org.br/nfse.xsd',
             'soapns' => 'http://ws.bhiss.pbh.gov.br'
+        ],
+        "3304557" => [
+            "municipio"     => "Rio de Janeiro",
+            "uf"            => "RJ",
+            "homologacao"   => "https://homologacao.notacarioca.rio.gov.br/WSNacional/nfse.asmx",
+            "producao"      => "https://notacarioca.rio.gov.br/WSNacional/nfse.asmx",
+            "version"       => "1.00",
+            'msgns'         => 'http://www.abrasf.org.br/nfse.xsd',
+            "soapns"        => "http://notacarioca.rio.gov.br/"
         ]
     ];
     


### PR DESCRIPTION
,
        "3304557" => [
            "municipio"     => "Rio de Janeiro",
            "uf"            => "RJ",
            "homologacao"   => "https://homologacao.notacarioca.rio.gov.br/WSNacional/nfse.asmx",
            "producao"      => "https://notacarioca.rio.gov.br/WSNacional/nfse.asmx",
            "version"       => "1.00",
            'msgns'         => 'http://www.abrasf.org.br/nfse.xsd',
            "soapns"        => "http://notacarioca.rio.gov.br/"
        ]