### PR TITLE
#37 Correção da RpsInterface

### DIFF
--- a/src/Rps.php
+++ b/src/Rps.php
@@ -16,7 +16,6 @@ namespace NFePHP\NFSeNac;
  */
 
 use stdClass;
-use NFePHP\Common\Certificate;
 use NFePHP\NFSeNac\RpsInterface;
 use NFePHP\NFSeNac\Common\Factory;
 use JsonSchema\Validator as JsonValid;

--- a/src/Rps.php
+++ b/src/Rps.php
@@ -46,9 +46,7 @@ class Rps implements RpsInterface
     }
     
     /**
-     * Convert Rps::class data in XML
-     * @param stdClass $rps
-     * @return string
+     * {@inheritdoc}
      */
     public function render(stdClass $rps = null)
     {

--- a/src/RpsInterface.php
+++ b/src/RpsInterface.php
@@ -17,5 +17,10 @@ namespace NFePHP\NFSeNac;
 
 interface RpsInterface
 {
-    public function render();
+    /**
+     * Convert Rps::class data in XML
+     * @param stdClass $rps
+     * @return string
+     */
+    public function render(stdClass $rps = null);
 }

--- a/src/RpsInterface.php
+++ b/src/RpsInterface.php
@@ -15,6 +15,8 @@ namespace NFePHP\NFSeNac;
  * @link      http://github.com/nfephp-org/sped-nfse-nacional for the canonical source repository
  */
 
+use stdClass;
+
 interface RpsInterface
 {
     /**

--- a/tests/RpsTest.php
+++ b/tests/RpsTest.php
@@ -3,7 +3,6 @@
 namespace NFePHP\NFSeNac\Tests;
 
 use NFePHP\NFSeNac\Rps;
-use NFePHP\NFSeNac\RpsInterface;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionMethod;

--- a/tests/RpsTest.php
+++ b/tests/RpsTest.php
@@ -92,32 +92,33 @@ class RpsTest extends TestCase
 
     public function testInterfaceImplementation()
     {
-        $interface = new ReflectionClass(RpsInterface::class);
-        $class     = new ReflectionClass(Rps::class);
-        
-        $interfaceMethods = $interface->getMethods(ReflectionMethod::IS_PUBLIC);
+        $class = new ReflectionClass(Rps::class);
 
-        foreach ($interfaceMethods as $interfaceMethod) {
-            $methodName = $interfaceMethod->getName();
-            $parameters = $interfaceMethod->getParameters();
+        foreach ($class->getInterfaces() as $interface) {
+            $interfaceMethods = $interface->getMethods(ReflectionMethod::IS_PUBLIC);
 
-            $classMethod = $class->getMethod($methodName);
-            $childParameters = $classMethod->getParameters();
+            foreach ($interfaceMethods as $interfaceMethod) {
+                $methodName = $interfaceMethod->getName();
+                $parameters = $interfaceMethod->getParameters();
 
-            $failMessage = sprintf(
-                'A assinatura do método %s::%s precisa estar igual na interface %s::%s.',
-                $class->name,
-                $methodName,
-                $interface->name,
-                $methodName
-            );
+                $classMethod = $class->getMethod($methodName);
+                $childParameters = $classMethod->getParameters();
 
-            if (empty($parameters)) {
-                $this->assertEmpty($childParameters, $failMessage);
-            }
+                $failMessage = sprintf(
+                    'A assinatura do método %s::%s precisa estar igual na interface %s::%s.',
+                    $class->name,
+                    $methodName,
+                    $interface->name,
+                    $methodName
+                );
 
-            foreach ($parameters as $index => $parameter) {
-                $this->assertEquals($parameter->__toString(), $childParameters[$index]->__toString(), $failMessage);
+                if (empty($parameters)) {
+                    $this->assertEmpty($childParameters, $failMessage);
+                }
+
+                foreach ($parameters as $index => $parameter) {
+                    $this->assertEquals($parameter->__toString(), $childParameters[$index]->__toString(), $failMessage);
+                }
             }
         }
     }

--- a/tests/RpsTest.php
+++ b/tests/RpsTest.php
@@ -3,7 +3,10 @@
 namespace NFePHP\NFSeNac\Tests;
 
 use NFePHP\NFSeNac\Rps;
+use NFePHP\NFSeNac\RpsInterface;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
 
 class RpsTest extends TestCase
 {
@@ -85,5 +88,37 @@ class RpsTest extends TestCase
         $expectedXml = file_get_contents($this->fixturesPath . 'rps_1_00.xml');
         //$this->assertXmlStringEqualsXmlString($expectedXml, $actualXml);
         $this->assertTrue(true);
+    }
+
+    public function testInterfaceImplementation()
+    {
+        $interface = new ReflectionClass(RpsInterface::class);
+        $class     = new ReflectionClass(Rps::class);
+        
+        $interfaceMethods = $interface->getMethods(ReflectionMethod::IS_PUBLIC);
+
+        foreach ($interfaceMethods as $interfaceMethod) {
+            $methodName = $interfaceMethod->getName();
+            $parameters = $interfaceMethod->getParameters();
+
+            $classMethod = $class->getMethod($methodName);
+            $childParameters = $classMethod->getParameters();
+
+            $failMessage = sprintf(
+                'A assinatura do método %s::%s precisa estar igual na interface %s::%s.',
+                $class->name,
+                $methodName,
+                $interface->name,
+                $methodName
+            );
+
+            if (empty($parameters)) {
+                $this->assertEmpty($childParameters, $failMessage);
+            }
+
+            foreach ($parameters as $index => $parameter) {
+                $this->assertEquals($parameter->__toString(), $childParameters[$index]->__toString(), $failMessage);
+            }
+        }
     }
 }


### PR DESCRIPTION
 Corrigida a `RpsInterface` para permitir que se passe o `stdClass` ao executar o método render(), assim como na classe que a implementa.

Closes #37 
