### PR TITLE
#39 Correção na geração do id do LoteRps

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -218,7 +218,7 @@ class Tools extends BaseTools
         $xmlsigned = $this->sign($xmlsigned, 'InfRps', 'Id');
         
         $contentmsg = "<GerarNfseEnvio xmlns=\"{$this->wsobj->msgns}\">"
-            . "<LoteRps Id=\"$lote\" versao=\"{$this->wsobj->version}\">"
+            . "<LoteRps Id=\"Lote$lote\" versao=\"{$this->wsobj->version}\">"
             . "<NumeroLote>$lote</NumeroLote>"
             . "<Cnpj>" . $this->config->cnpj . "</Cnpj>"
             . "<InscricaoMunicipal>" . $this->config->im . "</InscricaoMunicipal>"


### PR DESCRIPTION
Corrigida a geração do valor do atributo `Id` do `LoteRps` no RPS de envio, que estava causando um erro na validação do RPS.

Closes #39 