### PR TITLE
Correção erro de validação XML

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -188,7 +188,7 @@ class Tools extends BaseTools
             $content .= $xmlsigned;
         }
         $contentmsg = "<EnviarLoteRpsEnvio xmlns=\"{$this->wsobj->msgns}\">"
-            . "<LoteRps Id=\"$lote\" versao=\"{$this->wsobj->version}\">"
+            . "<LoteRps Id=\"Lote{$lote}\" versao=\"{$this->wsobj->version}\">"
             . "<NumeroLote>$lote</NumeroLote>"
             . "<Cnpj>" . $this->config->cnpj . "</Cnpj>"
             . "<InscricaoMunicipal>" . $this->config->im . "</InscricaoMunicipal>"


### PR DESCRIPTION
Correção necessária para resolver a falha de validação do XML quando número do lote é igual ao número do RPS.

Referênciado na issue #49 